### PR TITLE
Bug fix - prevent duplicate subscriptions. Improvement - simplify adapter implementation.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,7 @@
 	"forin"     : true,   //requires all `for in` loops to filter object's items with `hasOwnProperty()`
 	"immed"     : true,   //prohibits the use of immediate function invocations without wrapping them in parentheses
 	"indent"    : 4,      //enforces specific tab width
-	"latedef"   : true,   //prohibits the use of a variable before it was defined
+	"latedef"   : "nofunc",   //prohibits the use of a variable before it was defined
 	"newcap"    : true,   //requires you to capitalize names of constructor functions
 	"noarg"     : true,   //prohibits the use of `arguments.caller` and `arguments.callee`
 	"noempty"   : true,   //warns when you have an empty block in your code

--- a/README.md
+++ b/README.md
@@ -58,3 +58,38 @@ var logger = require("whistlepunk")(postal, config, host.fount);
 
 logger.debug("More info than you'd typically want to sift through....");
 ```
+
+###Custom Adapters
+Whistlepunk adapters modules must meet the following criteria:
+
+ * export a factory method that takes the adapter config
+ * provide an onLog method it can call on entries
+ * implement a singleton (requiring it multiple times should result in the same instance)
+
+Optionally, your adapter module can:
+
+ * return a promise
+ * provide a `constraint` predicate that filters log entries (one is provided by default that filters by level)
+ * accept a fount instance as a second argument to the factory method
+
+Debug adapter
+```js
+var debug = require( "debug" );
+var namespaces = {};
+var debugAdapter = {
+	onLog: function( data ) {
+		var debugNs = namespaces[ data.namespace ];
+		if ( !debugNs ) {
+			debugNs = namespaces[ data.namespace ] = debug( data.namespace );
+		}
+		debugNs( data.type, data.msg );
+	}
+};
+
+// factory method returns the same instance every time
+// this allows whistlepunk to prevent creating duplicate subscriptions
+// which would cause duplicate log entries
+module.exports = function( config ) {
+	return debugAdapter;
+};
+```

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "colors": "^1.0.3",
     "debug": "^2.1.1",
     "lodash": "^2.4.1",
-    "moment": "^2.8.4"
+    "moment": "^2.8.4",
+    "when": "^3.6.4"
   },
   "devDependencies": {
     "istanbul": "^0.3.2",
     "mocha": "^1.21.4",
+    "postal": "^0.12.3",
     "should": "^4.0.4"
   },
   "engines": {

--- a/src/adapters/autohost.js
+++ b/src/adapters/autohost.js
@@ -1,15 +1,21 @@
-module.exports = function( logChannel, config, fount ) {
-	if ( fount ) {
-		fount
-			.resolve( "ah" )
-			.then( function( host ) {
-				logChannel.subscribe( "#", function( data ) {
+var noOpAdapter = { onLog: function() {} };
+var adapter;
+
+function createAhAdapter( fount ) {
+	return fount
+		.resolve( "ah" )
+		.then( function( host ) {
+			return {
+				onLog: function( data ) {
 					if ( host && host.notifyClients ) {
 						host.notifyClients( data.type, data );
 					}
-				} ).constraint( function( data ) {
-					return data.level <= config.level;
-				} );
-			} );
-	}
+				}
+			};
+		} );
+}
+
+module.exports = function( config, fount ) {
+	adapter = adapter || ( fount ? createAhAdapter( fount ) : noOpAdapter );
+	return adapter;
 };

--- a/src/adapters/debug.js
+++ b/src/adapters/debug.js
@@ -1,14 +1,15 @@
 var debug = require( "debug" );
-var _ = require( "lodash" );
-module.exports = function( logChannel, config ) {
-	var namespaces = {};
-	logChannel.subscribe( "#", function( data ) {
-		var debugNs = namespaces[ data.namespace ]
+var namespaces = {};
+var debugAdapter = {
+	onLog: function( data ) {
+		var debugNs = namespaces[ data.namespace ];
 		if ( !debugNs ) {
 			debugNs = namespaces[ data.namespace ] = debug( data.namespace );
 		}
 		debugNs( data.type, data.msg );
-	} ).constraint( function( data ) {
-		return data.level <= config.level;
-	} );
+	}
+};
+
+module.exports = function( config ) {
+	return debugAdapter;
 };

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -1,11 +1,41 @@
 var _ = require( "lodash" );
 var fs = require( "fs" );
 var path = require( "path" );
-module.exports = function( channel, config, fount ) {
+var when = require( "when" );
+var builtIn = getAdapters();
 
-	_.each( config.adapters, function( adapterCfg, name ) {
-		var adapterPath = path.join( __dirname, "./adapters", name + ".js" );
-		var adapter = require( adapterPath )( channel, adapterCfg, fount );
-	} );
-
+function defaultConstraint( config ) {
+	return function levelConstraint( data ) {
+		return data.level <= config.level;
+	};
 }
+
+function getAdapters() {
+	var adapterPath = path.resolve( __dirname, "./adapters" );
+	var files = fs.readdirSync( adapterPath );
+	return _.reduce( files, function( acc, file ) {
+		acc[ file.split( "." )[ 0 ] ] = path.join( adapterPath, file );
+		return acc;
+	}, {} );
+}
+
+function wireUp( config, channel ) {
+	return function onAdapter( adapter ) {
+		var newSub = channel
+			.subscribe( adapter.topic || "#", adapter.onLog )
+			.constraint( adapter.constraint || defaultConstraint( config ) );
+		if ( adapter.subscription ) {
+			adapter.subscription.unsubscribe();
+		}
+		adapter.subscription = newSub;
+	};
+}
+
+module.exports = function( channel, config, fount ) {
+	_.each( config.adapters, function( adapterCfg, name ) {
+		var adapterPath = builtIn[ name ] || require.resolve( name );
+		var adapter = require( adapterPath )( adapterCfg, fount );
+		when( adapter )
+			.then( wireUp( adapterCfg, channel ) );
+	} );
+};


### PR DESCRIPTION
It was easy to create scenarios (specs) where Whistlepunk would wire up adapters multiple times causing the number of log entries to grow unbounded. This change may seem a little heavy-handed but I wanted to change things up so that Whistlepunk could ensure a correctly designed adapter would never end up with multiple subscriptions to the log channel.