### PR TITLE
Timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## 0.2.x
 
 ### Current
+ * Add support for topic based filtering on adapters
+ * Support multiple subscription topics for adapters
+ * Calling reset on a log should only affect adapter subscriptions that match the log's namespace
  * Provide consistent default timestamp using GMZ timezone in ISO
  * Add raw moment timestamp to data published to adapters
  * Add timestamp configuration to adapter configuration to allow users to customize format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## 0.2.x
 
+### Current
+ * Provide consistent default timestamp using GMZ timezone in ISO
+ * Add raw moment timestamp to data published to adapters
+ * Add timestamp configuration to adapter configuration to allow users to customize format
+
 ### 0.2.1
  * Refactored Logger to accept an optional timestamp
  * Timestamp is now a Date object instead of a integer

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > *noun* - a lumberjack who operates the signal wire running to a donkey engine whistle.
 
 ## What Is It?
-Logging.....sigh. It"s necessary, but often intrusive, heavy-handed and cumbersome...or it"s anemic and fails to satisfy the needs of Ops and Developers. Whistlepunk doesn"t care about what logging tools you love to use. It just cares that it needs to "blow the whistle" (i.e. - indicate something should be logged). You can plug your favorite logging tool into whistlepunk by writing an adapter for it (which consists of susbcribing to the postal "log" channel and writing the published log messages to your preferred logging library). At LeanKit, we"re using [debug]() a lot (during development) and then standard out for production logs - so whistlepunk has two adapters (currently) built-in.
+Logging.....sigh. It's necessary, but often intrusive, heavy-handed and cumbersome...or it's anemic and fails to satisfy the needs of Ops and Developers. Whistlepunk doesn't care about what logging tools you love to use. It just cares that it needs to "blow the whistle" (i.e. - indicate something should be logged). You can plug your favorite logging tool into whistlepunk by writing an adapter for it (which consists of susbcribing to the postal "log" channel and writing the published log messages to your preferred logging library). At LeanKit, we're using [debug]() a lot (during development) and then standard out for production logs - so whistlepunk has two adapters (currently) built-in.
 
 ## How Does it Work?
 If whistlepunk knows about your adapter, then including a section for that adapter in your configuration will enable it. For example, this config enables the "stdOut" and "debug" built-in adapters:
@@ -28,11 +28,11 @@ var config =  {
 var postal = require("postal");
 var logger = require("whistlepunk")(postal, config);
 
-logger.warn("Watch it, I"m warning you!");
+logger.warn("Watch it, I'm warning you!");
 ```
 
 ### Log Levels
-The log levels available are specified as integers (as in the above `level` value under each adapter"s configuration). Specifying a log level includes each level up to the level specified. For example, specifying a log level of "3" (info), will include warn (2) and error (1) log messages as well.
+The log levels available are specified as integers (as in the above `level` value under each adapter's configuration). Specifying a log level includes each level up to the level specified. For example, specifying a log level of "3" (info), will include warn (2) and error (1) log messages as well.
 
 * 0 - off
 * 1 - error
@@ -43,7 +43,7 @@ The log levels available are specified as integers (as in the above `level` valu
 ### Topics
 Topics provide a way for adapters to limit what log entries they accept based on the namespace of the logger publishing the log entry. Since `postal` is being used to handle this, AMQP style wildcards are a valid way to subscribe to parts of a namespace.
 
-Be aware that when calling `reset` on a log, all adapter subscriptions that match the log"s namespace will be unsubscribed.
+Be aware that when calling `reset` on a log, all adapter subscriptions that match the log's namespace will be unsubscribed.
 
 __example topics__
 ```javascript
@@ -72,7 +72,7 @@ The timestamp property has the following properties:
 #### Adapter Authors
 Whistelpunk provides adapters with two fields that can be used to display a timestamp. The `timestamp` field is an ISO8601 string in GMT. The `utc` field is a moment instance in UTC that can be used to apply a user-supplied format.
 
-A timeFormatter function that will adjust and format the timestamp according to the adapter"s configuration will be passed to your adapter"s constructor. It requires the configuration and data as arguments:
+A timeFormatter function that will adjust and format the timestamp according to the adapter's configuration will be passed to your adapter's constructor. It requires the configuration and data as arguments:
 
 ```javascript
 var timestamp = formatter( config, data );
@@ -81,7 +81,7 @@ var timestamp = formatter( config, data );
 See the [stdOut adapter](/blob/master/src/adapters/stdOut.js) for an example use case.
 
 ### Using With autohost
-It"s possible to use autohost to emit log messages over websockets to a client. To do so, you need to ensure autohost is registered with its fount instances as "ah", and pass the autohost fount instance to whistlepunk:
+It's possible to use autohost to emit log messages over websockets to a client. To do so, you need to ensure autohost is registered with its fount instances as "ah", and pass the autohost fount instance to whistlepunk:
 
 ```javascript
 var config =  {
@@ -101,7 +101,7 @@ var config =  {
 // assuming autohost instance is assigned to a "host" variable
 var logger = require("whistlepunk")(postal, config, host.fount);
 
-logger.debug("More info than you"d typically want to sift through....");
+logger.debug("More info than you'd typically want to sift through....");
 ```
 
 ### Custom Adapters
@@ -167,7 +167,7 @@ function createAhAdapter( fount ) {
 
 // because need fount to get a handle to the
 // autohost instance, return a no-op adapter
-// if it"s missing
+// if it's missing
 module.exports = function( config, formatter, fount ) {
 	adapter = adapter || ( fount ? createAhAdapter( fount ) : noOpAdapter );
 	return adapter;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > *noun* - a lumberjack who operates the signal wire running to a donkey engine whistle.
 
 ## What Is It?
-Logging.....sigh. It's necessary, but often intrusive, heavy-handed and cumbersome...or it's anemic and fails to satisfy the needs of Ops and Developers. Whistlepunk doesn't care about what logging tools you love to use. It just cares that it needs to "blow the whistle" (i.e. - indicate something should be logged). You can plug your favorite logging tool into whistlepunk by writing an adapter for it (which consists of susbcribing to the postal "log" channel and writing the published log messages to your preferred logging library). At LeanKit, we're using [debug]() a lot (during development) and then standard out for production logs - so whistlepunk has two adapters (currently) built-in.
+Logging.....sigh. It"s necessary, but often intrusive, heavy-handed and cumbersome...or it"s anemic and fails to satisfy the needs of Ops and Developers. Whistlepunk doesn"t care about what logging tools you love to use. It just cares that it needs to "blow the whistle" (i.e. - indicate something should be logged). You can plug your favorite logging tool into whistlepunk by writing an adapter for it (which consists of susbcribing to the postal "log" channel and writing the published log messages to your preferred logging library). At LeanKit, we"re using [debug]() a lot (during development) and then standard out for production logs - so whistlepunk has two adapters (currently) built-in.
 
 ## How Does it Work?
 If whistlepunk knows about your adapter, then including a section for that adapter in your configuration will enable it. For example, this config enables the "stdOut" and "debug" built-in adapters:
@@ -16,8 +16,9 @@ var config =  {
 			bailIfDebug: true, // disables stdOut if DEBUG=* is in play
 			timestamp: {
 				local: true, // defaults to UTC
-				format: 'MMM-D-YYYY hh:mm:ss A' // ex: Jan 1, 2015 10:15:20 AM
-			}
+				format: "MMM-D-YYYY hh:mm:ss A" // ex: Jan 1, 2015 10:15:20 AM
+			},
+			topic: "#", // default topic
 		},
 		"debug": {
 			level: 5
@@ -27,17 +28,31 @@ var config =  {
 var postal = require("postal");
 var logger = require("whistlepunk")(postal, config);
 
-logger.warn("Watch it, I'm warning you!");
+logger.warn("Watch it, I"m warning you!");
 ```
 
 ### Log Levels
-The log levels available are specified as integers (as in the above `level` value under each adapter's configuration). Specifying a log level includes each level up to the level specified. For example, specifying a log level of "3" (info), will include warn (2) and error (1) log messages as well.
+The log levels available are specified as integers (as in the above `level` value under each adapter"s configuration). Specifying a log level includes each level up to the level specified. For example, specifying a log level of "3" (info), will include warn (2) and error (1) log messages as well.
 
 * 0 - off
 * 1 - error
 * 2 - warn
 * 3 - info
 * 4 - debug
+
+### Topics
+Topics provide a way for adapters to limit what log entries they accept based on the namespace of the logger publishing the log entry. Since `postal` is being used to handle this, AMQP style wildcards are a valid way to subscribe to parts of a namespace.
+
+Be aware that when calling `reset` on a log, all adapter subscriptions that match the log"s namespace will be unsubscribed.
+
+__example topics__
+```javascript
+	topic: "#" // will subscribe to all logs
+	topic: "autohost.#" // will subscribe to all autohost loggers
+	topic: "#.errors" // would subscribe to any logger with a namespace ending in "error"
+	topic: "myApp.#,autohost.#" // subscribes to `myApp.#` and `autohost.#`
+	topic: [ "myApp.#", "autohost.#" ] // same as above but
+```
 
 ### Timestamps
 Whistlepunk uses moment.js to capture and format timestamps. Timestamps will default to Greenwich Mean Time and the ISO8601 format.
@@ -57,7 +72,7 @@ The timestamp property has the following properties:
 #### Adapter Authors
 Whistelpunk provides adapters with two fields that can be used to display a timestamp. The `timestamp` field is an ISO8601 string in GMT. The `utc` field is a moment instance in UTC that can be used to apply a user-supplied format.
 
-A timeFormatter function that will adjust and format the timestamp according to the adapter's configuration will be passed to your adapter's constructor. It requires the configuration and data as arguments:
+A timeFormatter function that will adjust and format the timestamp according to the adapter"s configuration will be passed to your adapter"s constructor. It requires the configuration and data as arguments:
 
 ```javascript
 var timestamp = formatter( config, data );
@@ -66,7 +81,7 @@ var timestamp = formatter( config, data );
 See the [stdOut adapter](/blob/master/src/adapters/stdOut.js) for an example use case.
 
 ### Using With autohost
-It's possible to use autohost to emit log messages over websockets to a client. To do so, you need to ensure autohost is registered with its fount instances as "ah", and pass the autohost fount instance to whistlepunk:
+It"s possible to use autohost to emit log messages over websockets to a client. To do so, you need to ensure autohost is registered with its fount instances as "ah", and pass the autohost fount instance to whistlepunk:
 
 ```javascript
 var config =  {
@@ -86,7 +101,7 @@ var config =  {
 // assuming autohost instance is assigned to a "host" variable
 var logger = require("whistlepunk")(postal, config, host.fount);
 
-logger.debug("More info than you'd typically want to sift through....");
+logger.debug("More info than you"d typically want to sift through....");
 ```
 
 ### Custom Adapters
@@ -152,7 +167,7 @@ function createAhAdapter( fount ) {
 
 // because need fount to get a handle to the
 // autohost instance, return a no-op adapter
-// if it's missing
+// if it"s missing
 module.exports = function( config, formatter, fount ) {
 	adapter = adapter || ( fount ? createAhAdapter( fount ) : noOpAdapter );
 	return adapter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whistlepunk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/LeanKit-Labs/whistlepunk",
   "description": "Logging abstraction that signals any enabled adapters of a new log message.",
   "author": "LeanKit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whistlepunk",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "homepage": "https://github.com/LeanKit-Labs/whistlepunk",
   "description": "Logging abstraction that signals any enabled adapters of a new log message.",
   "author": "LeanKit",

--- a/spec/behavior/adapters.spec.js
+++ b/spec/behavior/adapters.spec.js
@@ -5,12 +5,14 @@ describe( "Built-in Adapters", function() {
 		describe( "when debug is not enabled", function() {
 			describe( "with default timestamp", function() {
 
-				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp, realLog;
 				before( function() {
 					msg = "Testing stdOut";
 					timestamp = /[0-9]{4}[-][0-9]{2}[-][0-9]{2}T[0-9]{2}[:][0-9]{2}[:][0-9]{2}[.][0-9]{3}Z/;
 					noMsg = "Shouldn't show up";
 					wp = getWhistlepunk();
+					realLog = console.log;
+					console.log = function() {};
 					consoleLog = sinon.spy( console, "log" );
 					logFactory = wp( postal, {
 						adapters: {
@@ -28,6 +30,7 @@ describe( "Built-in Adapters", function() {
 					logger.reset();
 					postal.reset();
 					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with ISO8601 in GMT)", function() {
@@ -65,12 +68,14 @@ describe( "Built-in Adapters", function() {
 
 			describe( "with custom timestamp", function() {
 
-				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp, realLog;
 				before( function() {
 					msg = "Testing stdOut";
 					timestamp = /[0-9]{1,2}[:][0-9]{2}[ ](AM|PM)[ ][-][ ][a-zA-Z]{3}[ ][0-9]{1,2}[a-z]{2,3}[,][ ][0-9]{4}[-+][0]{4}/;
 					noMsg = "Shouldn't show up";
 					wp = getWhistlepunk();
+					realLog = console.log;
+					console.log = function() {};
 					consoleLog = sinon.spy( console, "log" );
 					logFactory = wp( postal, {
 						adapters: {
@@ -91,6 +96,7 @@ describe( "Built-in Adapters", function() {
 					logger.reset();
 					postal.reset();
 					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with custom in GMT)", function() {
@@ -128,12 +134,14 @@ describe( "Built-in Adapters", function() {
 
 			describe( "with custom timestamp", function() {
 
-				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp, realLog;
 				before( function() {
 					msg = "Testing stdOut";
 					timestamp = /[0-9]{1,2}[:][0-9]{2}[ ](AM|PM)[ ][-][ ][a-zA-Z]{3}[ ][0-9]{1,2}[a-z]{2,3}[,][ ][0-9]{4}[-+][0-9][1-9][0-9]{2}/;
 					noMsg = "Shouldn't show up";
 					wp = getWhistlepunk();
+					realLog = console.log;
+					console.log = function() {};
 					consoleLog = sinon.spy( console, "log" );
 					logFactory = wp( postal, {
 						adapters: {
@@ -155,6 +163,7 @@ describe( "Built-in Adapters", function() {
 					logger.reset();
 					postal.reset();
 					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with custom in GMT)", function() {
@@ -194,9 +203,12 @@ describe( "Built-in Adapters", function() {
 
 				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
 				var filter = /(?:\S+\s){2}([a-zA-Z0-9.]+)/;
+				var realLog;
 				before( function() {
 					msg = "Testing stdOut";
 					wp = getWhistlepunk();
+					realLog = console.log;
+					console.log = function() {};
 					consoleLog = sinon.spy( console, "log" );
 					logFactory = wp( postal, {
 						adapters: {
@@ -254,8 +266,10 @@ describe( "Built-in Adapters", function() {
 				} );
 
 				after( function() {
-					postal.reset();
 					consoleLog.restore();
+					console.log = realLog;
+					postal.reset();
+
 				} );
 
 				it( "should log the correct number of messages", function() {

--- a/spec/behavior/adapters.spec.js
+++ b/spec/behavior/adapters.spec.js
@@ -24,13 +24,13 @@ describe( "Built-in Adapters", function() {
 					logger = logFactory( "stdout-test" );
 					logger.warn( msg );
 					logger.info( noMsg );
+					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				after( function() {
 					logger.reset();
 					postal.reset();
-					consoleLog.restore();
-					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with ISO8601 in GMT)", function() {
@@ -90,13 +90,13 @@ describe( "Built-in Adapters", function() {
 					logger = logFactory( "stdout-test" );
 					logger.warn( msg );
 					logger.info( noMsg );
+					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				after( function() {
 					logger.reset();
 					postal.reset();
-					consoleLog.restore();
-					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with custom in GMT)", function() {
@@ -157,13 +157,13 @@ describe( "Built-in Adapters", function() {
 					logger = logFactory( "stdout-test" );
 					logger.warn( msg );
 					logger.info( noMsg );
+					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				after( function() {
 					logger.reset();
 					postal.reset();
-					consoleLog.restore();
-					console.log = realLog;
 				} );
 
 				it( "should log the message to the console (with custom in GMT)", function() {
@@ -263,13 +263,12 @@ describe( "Built-in Adapters", function() {
 
 					logger1a.reset();
 					logger1b.reset();
+					consoleLog.restore();
+					console.log = realLog;
 				} );
 
 				after( function() {
-					consoleLog.restore();
-					console.log = realLog;
 					postal.reset();
-
 				} );
 
 				it( "should log the correct number of messages", function() {

--- a/spec/behavior/adapters.spec.js
+++ b/spec/behavior/adapters.spec.js
@@ -3,61 +3,191 @@ describe( "Built-in Adapters", function() {
 	describe( "when using the stdOut adapter", function() {
 
 		describe( "when debug is not enabled", function() {
+			describe( "with default timestamp", function() {
 
-			var logFactory, logger, consoleLog, msg, noMsg, wp;
-			before( function() {
-				msg = "Testing stdOut";
-				noMsg = "Shouldn't show up";
-				wp = getWhistlepunk();
-				consoleLog = sinon.spy( console, "log" );
-				logFactory = wp( postal, {
-					adapters: {
-						stdOut: {
-							level: 2
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				before( function() {
+					msg = "Testing stdOut";
+					timestamp = /[0-9]{4}[-][0-9]{2}[-][0-9]{2}T[0-9]{2}[:][0-9]{2}[:][0-9]{2}[.][0-9]{3}Z/;
+					noMsg = "Shouldn't show up";
+					wp = getWhistlepunk();
+					consoleLog = sinon.spy( console, "log" );
+					logFactory = wp( postal, {
+						adapters: {
+							stdOut: {
+								level: 2
+							}
+						}
+					} );
+					logger = logFactory( "stdout-test" );
+					logger.warn( msg );
+					logger.info( noMsg );
+				} );
+
+				after( function() {
+					logger.reset();
+					postal.reset();
+					consoleLog.restore();
+				} );
+
+				it( "should log the message to the console (with ISO8601 in GMT)", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( msg );
+					var pass = false;
+
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) && timestamp.test( arg ) ) {
+							pass = true;
 						}
 					}
+
+					pass.should.be.ok;
 				} );
-				logger = logFactory( "stdout-test" );
-				logger.warn( msg );
-				logger.info( noMsg );
-			} );
 
-			after( function() {
-				logger.reset();
-				postal.reset();
-				consoleLog.restore();
-			} );
+				it( "should not log any statements above its level", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( noMsg );
+					var pass = true;
 
-			it( "should log the message to the console", function() {
-				var count = consoleLog.callCount;
-				var regex = new RegExp( msg );
-				var pass = false;
-
-				var arg;
-				for (var i = 0; i < count; i++) {
-					arg = consoleLog.getCall( i ).args[ 0 ];
-					if ( regex.test( arg ) ) {
-						pass = true;
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) ) {
+							pass = false;
+						}
 					}
-				}
 
-				pass.should.be.ok;
+					pass.should.be.ok;
+				} );
 			} );
 
-			it( "should not log any statements above its level", function() {
-				var count = consoleLog.callCount;
-				var regex = new RegExp( noMsg );
-				var pass = true;
+			describe( "with custom timestamp", function() {
 
-				var arg;
-				for (var i = 0; i < count; i++) {
-					arg = consoleLog.getCall( i ).args[ 0 ];
-					if ( regex.test( arg ) ) {
-						pass = false;
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				before( function() {
+					msg = "Testing stdOut";
+					timestamp = /[0-9]{1,2}[:][0-9]{2}[ ](AM|PM)[ ][-][ ][a-zA-Z]{3}[ ][0-9]{1,2}[a-z]{2,3}[,][ ][0-9]{4}[-+][0]{4}/;
+					noMsg = "Shouldn't show up";
+					wp = getWhistlepunk();
+					consoleLog = sinon.spy( console, "log" );
+					logFactory = wp( postal, {
+						adapters: {
+							stdOut: {
+								level: 2,
+								timestamp: {
+									format: "h:mm A - MMM Do, YYYYZZ"
+								}
+							}
+						}
+					} );
+					logger = logFactory( "stdout-test" );
+					logger.warn( msg );
+					logger.info( noMsg );
+				} );
+
+				after( function() {
+					logger.reset();
+					postal.reset();
+					consoleLog.restore();
+				} );
+
+				it( "should log the message to the console (with custom in GMT)", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( msg );
+					var pass = false;
+
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) && timestamp.test( arg ) ) {
+							pass = true;
+						}
 					}
-				}
 
-				pass.should.be.ok;
+					pass.should.be.ok;
+				} );
+
+				it( "should not log any statements above its level", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( noMsg );
+					var pass = true;
+
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) ) {
+							pass = false;
+						}
+					}
+
+					pass.should.be.ok;
+				} );
+			} );
+
+			describe( "with custom timestamp", function() {
+
+				var logFactory, logger, consoleLog, msg, noMsg, wp, timestamp;
+				before( function() {
+					msg = "Testing stdOut";
+					timestamp = /[0-9]{1,2}[:][0-9]{2}[ ](AM|PM)[ ][-][ ][a-zA-Z]{3}[ ][0-9]{1,2}[a-z]{2,3}[,][ ][0-9]{4}[-+][0-9][1-9][0-9]{2}/;
+					noMsg = "Shouldn't show up";
+					wp = getWhistlepunk();
+					consoleLog = sinon.spy( console, "log" );
+					logFactory = wp( postal, {
+						adapters: {
+							stdOut: {
+								level: 2,
+								timestamp: {
+									local: true,
+									format: "h:mm A - MMM Do, YYYYZZ"
+								}
+							}
+						}
+					} );
+					logger = logFactory( "stdout-test" );
+					logger.warn( msg );
+					logger.info( noMsg );
+				} );
+
+				after( function() {
+					logger.reset();
+					postal.reset();
+					consoleLog.restore();
+				} );
+
+				it( "should log the message to the console (with custom in GMT)", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( msg );
+					var pass = false;
+
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) && timestamp.test( arg ) ) {
+							pass = true;
+						}
+					}
+
+					pass.should.be.ok;
+				} );
+
+				it( "should not log any statements above its level", function() {
+					var count = consoleLog.callCount;
+					var regex = new RegExp( noMsg );
+					var pass = true;
+
+					var arg;
+					for (var i = 0; i < count; i++) {
+						arg = consoleLog.getCall( i ).args[ 0 ];
+						if ( regex.test( arg ) ) {
+							pass = false;
+						}
+					}
+
+					pass.should.be.ok;
+				} );
 			} );
 		} );
 

--- a/spec/behavior/logger.spec.js
+++ b/spec/behavior/logger.spec.js
@@ -9,9 +9,11 @@ describe( "Logger.js", function() {
 			publish: sinon.stub(),
 		};
 		adapterStub = {
-			subscription: {
-				unsubscribe: sinon.stub()
-			}
+			subscriptions: [
+				{
+					unsubscribe: sinon.stub()
+				}
+			]
 		};
 		logger = new (ctorFactory( channelStub ))( "test", [ adapterStub ] );
 	} );
@@ -19,7 +21,7 @@ describe( "Logger.js", function() {
 	describe( "when calling reset", function() {
 		it( "should unsubscribe all adapters", function() {
 			logger.reset();
-			adapterStub.subscription.unsubscribe.should.be.calledOnce;
+			adapterStub.subscriptions[ 0 ].unsubscribe.should.be.calledOnce;
 		} );
 	} );
 } );

--- a/spec/behavior/logger.spec.js
+++ b/spec/behavior/logger.spec.js
@@ -16,19 +16,6 @@ describe( "Logger.js", function() {
 		logger = new (ctorFactory( channelStub ))( "test", [ adapterStub ] );
 	} );
 
-	describe( "when calling logIt", function() {
-		it( "should use a default timestamp if not provided", function() {
-			logger.logIt( "info", [ "Please, I'll use your datetime..." ] );
-			channelStub.publish.firstCall.args[ 1 ].timestamp.should.be.a( "Date" );
-		} );
-		it( "should use a passed timestamp if provided", function() {
-			var myTimestamp = new Date();
-			logger.logIt( "info", [ "Please, use my datetime..." ], myTimestamp );
-			channelStub.publish.firstCall.args[ 1 ].timestamp.should.be.a( "Date" );
-			channelStub.publish.firstCall.args[ 1 ].timestamp.should.equal( myTimestamp );
-		} );
-	} );
-
 	describe( "when calling reset", function() {
 		it( "should unsubscribe all adapters", function() {
 			logger.reset();

--- a/spec/behavior/logger.spec.js
+++ b/spec/behavior/logger.spec.js
@@ -15,7 +15,9 @@ describe( "Logger.js", function() {
 				}
 			]
 		};
-		logger = new (ctorFactory( channelStub ))( "test", [ adapterStub ] );
+		logger = new (ctorFactory( channelStub, function() {
+			return true;
+		} ))( "test", [ adapterStub ] );
 	} );
 
 	describe( "when calling reset", function() {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,5 +1,6 @@
 var util = require( "util" );
 var _ = require( "lodash" );
+var moment = require( "moment" );
 module.exports = function( channel ) {
 	var logLevels = [ "off", "error", "warn", "info", "debug" ];
 
@@ -10,9 +11,11 @@ module.exports = function( channel ) {
 
 	Logger.prototype.logIt = function logIt( type, data, timestamp ) {
 		var msg = ( typeof data[ 0 ] === "string" ) ? util.format.apply( null, data ) : data;
+		var utc = moment.utc();
 		var payload = {
 			msg: msg,
-			timestamp: timestamp || new Date(),
+			timestamp: utc.toISOString(),
+			utc: utc,
 			type: type,
 			level: logLevels.indexOf( type ),
 			namespace: this.namespace

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,9 +1,7 @@
 var util = require( "util" );
 var _ = require( "lodash" );
 var moment = require( "moment" );
-var postal = require( "postal" );
-var resolve = postal.configuration.resolver.compare.bind( postal.configuration.resolver );
-module.exports = function( channel ) {
+module.exports = function( channel, resolve ) {
 	var logLevels = [ "off", "error", "warn", "info", "debug" ];
 
 	function Logger( ns, adapters ) {

--- a/src/adapters/autohost.js
+++ b/src/adapters/autohost.js
@@ -19,7 +19,7 @@ function createAhAdapter( fount ) {
 	};
 }
 
-module.exports = function( config, fount ) {
+module.exports = function( config, formatter, fount ) {
 	adapter = adapter || ( fount ? createAhAdapter( fount ) : noOpAdapter );
 	return adapter;
 };

--- a/src/adapters/stdOut.js
+++ b/src/adapters/stdOut.js
@@ -1,9 +1,8 @@
 var colors = require( "colors" );
-var moment = require( "moment" );
 var _ = require( "lodash" );
 var adapter;
 
-function configure( config ) {
+function configure( config, formatter ) {
 	var envDebug = !!process.env.DEBUG;
 
 	var theme = _.extend( {
@@ -23,7 +22,8 @@ function configure( config ) {
 			} else {
 				msg = data.msg;
 			}
-			console.log( colors[ data.type ]( moment( data.timestamp ).format(), data.namespace || "", msg ) );
+			var timestamp = formatter( config, data );
+			console.log( colors[ data.type ]( timestamp, data.namespace || "", msg ) );
 		},
 		constraint: function( data ) {
 			return data.level <= config.level && ( !config.bailIfDebug || ( config.bailIfDebug && !envDebug ) );
@@ -31,7 +31,7 @@ function configure( config ) {
 	};
 }
 
-module.exports = function( config ) {
-	configure( config );
+module.exports = function( config, formatter ) {
+	configure( config, formatter );
 	return adapter;
 };

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -48,14 +48,24 @@ function wireUp( adapterFsm, config, channel, adapter ) {
 		}
 	}
 
-	var newSub = channel
-		.subscribe( adapter.topic || "#", handler )
-		.constraint( adapter.constraint || defaultConstraint( config ) );
-	if ( adapter.subscription ) {
-		adapter.subscription.unsubscribe();
+	var topics;
+	if ( config.topic && _.isArray( config.topic ) ) {
+		topics = config.topic;
+	} else {
+		topics = ( config.topic || "#" ).split( "," );
 	}
+	var subscriptions = _.map( topics, function( topic ) {
+		return channel
+			.subscribe( topic, handler )
+			.constraint( adapter.constraint || defaultConstraint( config ) );
+	} );
 
-	adapter.subscription = newSub;
+	if ( adapter.subscriptions ) {
+		_.each( adapter.subscriptions, function( subscription ) {
+			subscription.unsubscribe();
+		} );
+	}
+	adapter.subscriptions = subscriptions;
 }
 
 module.exports = function( channel, config, fount ) {

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -20,6 +20,19 @@ function getAdapters() {
 	}, {} );
 }
 
+function timeFormatter( config, data ) {
+	var time = config.timestamp;
+	if ( time ) {
+		if ( time.local ) {
+			data.utc.local();
+		}
+		return data.utc.format( time.format || "YYYY-MM-DDTHH:mm:ss.SSSZ" );
+	} else {
+		return data.timestamp;
+	}
+	return config.timeformat ? data.raw.format( config.format ) : data.timestamp;
+}
+
 function wireUp( adapterFsm, config, channel, adapter ) {
 
 	var fsm;
@@ -27,14 +40,12 @@ function wireUp( adapterFsm, config, channel, adapter ) {
 	var handler = adapter.onLog;
 
 	if ( _.isFunction( adapter.init ) ) {
-
 		init = adapter.init();
 
 		if ( init && init.then ) {
 			adapterFsm.register( adapter, init );
 			handler = adapterFsm.onLog.bind( adapterFsm, adapter );
 		}
-
 	}
 
 	var newSub = channel
@@ -45,20 +56,17 @@ function wireUp( adapterFsm, config, channel, adapter ) {
 	}
 
 	adapter.subscription = newSub;
-
 }
 
 module.exports = function( channel, config, fount ) {
-
 	var adapterFsm = require( "./adapter.fsm" );
 
 	return _.map( config.adapters, function( adapterCfg, name ) {
 		var adapterPath = builtIn[ name ] || require.resolve( name );
-		var adapter = require( adapterPath )( adapterCfg, fount );
+		var adapter = require( adapterPath )( adapterCfg, timeFormatter, fount );
 
 		wireUp( adapterFsm, adapterCfg, channel, adapter );
 
 		return adapter;
-
 	} );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ var _ = require( "lodash" );
 module.exports = function( postal, config, fount ) {
 	config = config || {};
 	var log = postal.channel( config.logChannel || "log" );
-	var Logger = require( "./Logger.js" )( log );
+	var resolver = postal.configuration.resolver.compare.bind( postal.configuration.resolver );
+	var Logger = require( "./Logger.js" )( log, resolver );
 	var adapters = require( "./configParser" )( log, config, fount );
 
 	function loggerFactory( namespace ) {


### PR DESCRIPTION
This represents breaking changes. Consider bumping version to 0.3.0.

 * Defaults timestamps to ISO8601 in GMT
 * Provides raw moment UTC instance on log data
 * Define timestamp configuration for adapters
 * Provide timeFormatter function to all adapter factories to make compliance with customization simple
 * Allow adapters to filter log entries based on topic matched against logger namespace