### PR TITLE
use appropriate console method for logging in stdOut adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+*.swp
+*.sw0
 *.suo
 *.csproj.user
 bin

--- a/src/adapters/stdOut.js
+++ b/src/adapters/stdOut.js
@@ -12,6 +12,13 @@ function configure( config, formatter ) {
 		error: "red"
 	}, config.theme );
 
+  var logType = {
+    info: "info",
+    warn: "warn",
+    debug: "log",
+    error: "error"
+  };
+
 	colors.setTheme( theme );
 
 	adapter = adapter || {
@@ -23,7 +30,7 @@ function configure( config, formatter ) {
 				msg = data.msg;
 			}
 			var timestamp = formatter( config, data );
-			console.log( colors[ data.type ]( timestamp, data.namespace || "", msg ) );
+			console[logType[data.type]]( colors[ data.type ]( timestamp, data.namespace || "", msg ) );
 		},
 		constraint: function( data ) {
 			return data.level <= config.level && ( !config.bailIfDebug || ( config.bailIfDebug && !envDebug ) );


### PR DESCRIPTION
I would like to have the stdOut adapter use a more appropriate `console` method for the various log levels. This will make it easier for me to separate stdOut vs stdErr in my log files. 

I've made a suggested adjustment in this pull request, and it appears to be working in my application. 

the gist of it is this mapping from log type to console method:

```js
  var logType = {
    info: "info",
    warn: "warn",
    debug: "log",
    error: "error"
  };
```

this will use the appropriate `console.[info/warn/log/error]' method for the various log levels

I have been unable to get the unit tests for whistlepunk to run on my box so I haven't been able to write a test around the use of the various console methods.