### PR TITLE
Bumping lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "colors": "1.0.3",
     "debug": "2.2.0",
-    "lodash": "3.x",
+    "lodash": "3.10.x",
     "machina": "1.x",
     "moment": "2.10.2",
     "when": "3.x",


### PR DESCRIPTION
My project has `lodash@3.5.0` in dependency because it match your `package.json` version npm doesn't install je last version of lodash. The problem is there is no function `eq` in `lodash@3.5.0` so there is an error here : `src/adapters/stdOut.js:6` (TypeError: _.eq is not a function)